### PR TITLE
fix: check script run on all OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "https-proxy-agent": "^5.0.1",
     "husky": "^7.0.0",
     "node-fetch": "^3.2.0",
+    "prettier": "^2.6.2",
     "pretty-quick": "^3.1.3",
     "sass": "^1.51.0",
     "typescript": "^4.6.4",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -83,7 +83,10 @@ async function resolveClashMeta() {
 async function resolveSidecar() {
   const sidecarDir = path.join(cwd, "src-tauri", "sidecar");
 
-  const host = execSync("rustc -vV | grep host").toString().slice(6).trim();
+  const host = execSync("rustc -vV")
+    .toString()
+    .match(/(?<=host: ).+(?=\s*)/g)[0];
+
   const ext = process.platform === "win32" ? ".exe" : "";
 
   await clash();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,6 +1913,11 @@ postcss@^8.4.13:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
 pretty-quick@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.1.3.tgz#15281108c0ddf446675157ca40240099157b638e"


### PR DESCRIPTION
1. Windows 系统没有 grep，跑 check 脚本时会出错，换成了用正则匹配的方式获取 host
测试地址 [regexr.com/6n3t7](https://regexr.com/6n3t7)
2. 开发依赖貌似缺失`prettire`，导致提交失败