### PR TITLE
Add support for windows arm64

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -42,6 +42,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev libayatana-appindicator3-dev
 
+      - name: Install ARM64 toolchain (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        run: |
+          rustup target add aarch64-pc-windows-msvc
+
       - name: Get yarn cache dir path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -75,6 +80,23 @@ jobs:
           releaseBody: "Alpha Version"
           releaseDraft: true
           prerelease: true
+
+      - name: Tauri build arm64 (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        uses: tauri-apps/tauri-action@0e558392ccadcb49bcc89e7df15a400e8f0c954d
+        # enable cache even though failed
+        # continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        with:
+          tagName: alpha
+          releaseName: "Clash Verge Alpha"
+          releaseBody: "Alpha Version"
+          releaseDraft: true
+          prerelease: true
+          args: --target aarc64-pc-windows-msvc
 
       # - name: Portable Bundle
       #   if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev libayatana-appindicator3-dev
 
+      - name: Install ARM64 toolchain (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        run: |
+          rustup target add aarch64-pc-windows-msvc
+
       - name: Get yarn cache dir path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -75,6 +80,23 @@ jobs:
           releaseDraft: false
           prerelease: true
 
+      - name: Tauri build arm64 (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        uses: tauri-apps/tauri-action@0e558392ccadcb49bcc89e7df15a400e8f0c954d
+        # enable cache even though failed
+        # continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        with:
+          tagName: v__VERSION__
+          releaseName: "Clash Verge v__VERSION__"
+          releaseBody: "More new features are now supported."
+          releaseDraft: false
+          prerelease: true
+          args: --target aarc64-pc-windows-msvc
+      
       - name: Portable Bundle
         if: matrix.os == 'windows-latest'
         # rebuild with env settings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev build-essential curl wget libssl-dev libgtk-3-dev libappindicator3-dev librsvg2-dev libayatana-appindicator3-dev
+      
+      - name: Install ARM64 toolchain (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        run: |
+          rustup target add aarch64-pc-windows-msvc
 
       - name: Get yarn cache dir path
         id: yarn-cache-dir-path
@@ -80,3 +85,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+      
+      - name: Tauri build arm64 (windows only)
+        if: startsWith(matrix.os, 'windows-')
+        uses: tauri-apps/tauri-action@0e558392ccadcb49bcc89e7df15a400e8f0c954d
+        # enable cache even though failed
+        # continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        with:
+          args: --target aarc64-pc-windows-msvc


### PR DESCRIPTION
Since github action's MSVC supports arm64, it should be easy to use rustup to add arm64 target for arm64 windows devices (Like Surface Pro X)