### PR TITLE
fix: matchMedia().addEventListener #258

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,27 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Clash Verge</title>
+    <script>
+      (function () {
+        var _matchMedia = window.matchMedia;
+        window.matchMedia = function () {
+          var v = _matchMedia.apply(null, arguments);
+          if (!v.addEventListener) {
+            v.addEventListener = function () {
+              if (arguments.length < 2 || arguments[0] !== "change") {
+                console.error("Cannot proxy addEventListener:", arguments);
+                return;
+              }
+              if (arguments.length > 2) {
+                console.warn("Proxy addEventListener:", arguments);
+              }
+              v.addListener(arguments[1]);
+            };
+          }
+          return v;
+        };
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
已在 v1.1.2、v1.0.6 测试可行。

macOS 10.15.3
Safari 13.0.5