### PR TITLE
fix: Virtuoso no work in legacy browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@juggle/resize-observer": "^3.4.0",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.13",
     "@mui/x-data-grid": "^5.17.11",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,11 @@
 /// <reference types="vite-plugin-svgr/client" />
 import "./assets/styles/index.scss";
 
+import { ResizeObserver } from "@juggle/resize-observer";
+if (!window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserver;
+}
+
 import React from "react";
 import ReactDOM from "react-dom";
 import { RecoilRoot } from "recoil";

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,6 +482,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@juggle/resize-observer@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
+
 "@mui/base@5.0.0-alpha.105":
   version "5.0.0-alpha.105"
   resolved "https://registry.npmmirror.com/@mui/base/-/base-5.0.0-alpha.105.tgz#ddf92c86db3355e0fe6886a818be073e2ee9a9f9"


### PR DESCRIPTION
Proxies 界面空白

https://github.com/petyosi/react-virtuoso/tree/7ae2d7fbc86e7368a6e18084b8802c6d0f3b8312#browser-support