### PR TITLE
add openssl

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
       "shortDescription": "A Clash GUI based on tauri.",
       "longDescription": "A Clash GUI based on tauri.",
       "deb": {
-        "depends": []
+        "depends": ["openssl"]
       },
       "macOS": {
         "frameworks": [],


### PR DESCRIPTION
本地 build 了一下，在 control 文件里看到了

```
Package: clash-verge
Version: 1.2.3
Architecture: amd64
Installed-Size: 69307
Maintainer: zzzgydi
Depends: openssl, libayatana-appindicator3-1, libwebkit2gtk-4.0-37, libgtk-3-0
Description: A Clash GUI based on tauri.
 A Clash GUI based on tauri.
Priority: optional
```

藏得好深。
