### PR TITLE
Update check.mjs CLASH_LATEST_DATE to latest

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -17,7 +17,7 @@ const SIDECAR_HOST = execSync("rustc -vV")
 /* ======= clash ======= */
 const CLASH_URL_PREFIX =
   "https://github.com/Dreamacro/clash/releases/download/premium/";
-const CLASH_LATEST_DATE = "2023.03.04";
+const CLASH_LATEST_DATE = "2023.03.18";
 
 const CLASH_MAP = {
   "win32-x64": "clash-windows-amd64",


### PR DESCRIPTION
This fixes the clash binary download error

<img width="859" alt="Screenshot 2023-03-26 at 6 26 56 AM" src="https://user-images.githubusercontent.com/800668/227749557-b88af358-4492-4703-8b63-1e37a1259db0.png">
