### PR TITLE
fix: Do not render div as a descendant of p

### DIFF
--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -40,7 +40,7 @@ export const ProxyRender = (props: RenderProps) => {
         <ListItemText
           primary={group.name}
           secondary={
-            <Box
+            <ListItemTextChild
               sx={{
                 overflow: "hidden",
                 display: "flex",
@@ -50,7 +50,7 @@ export const ProxyRender = (props: RenderProps) => {
             >
               <StyledTypeBox>{group.type}</StyledTypeBox>
               <StyledSubtitle>{group.now}</StyledSubtitle>
-            </Box>
+            </ListItemTextChild>
           }
           secondaryTypographyProps={{
             sx: { display: "flex", alignItems: "center" },
@@ -142,7 +142,11 @@ const StyledSubtitle = styled("span")`
   white-space: nowrap;
 `;
 
-const StyledTypeBox = styled(Box)(({ theme }) => ({
+const ListItemTextChild = styled("span")`
+  display: block;
+`;
+
+const StyledTypeBox = styled(ListItemTextChild)(({ theme }) => ({
   display: "inline-block",
   border: "1px solid #ccc",
   borderColor: alpha(theme.palette.primary.main, 0.5),


### PR DESCRIPTION
Hi, 
Thanks for the nice project, I had this idea of making a client for Clash and found out about yours, now I can read it, learn a lot from it, and all of the work related to building/distribution is already done by your scripts :)

## issue
This PR fixes a React warning in the client side of the project which was the first thing that got my attention when I built and started the project on my machine :)

Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/129622680/229323673-85bbd25c-a06d-43ec-82f7-042673ba0de4.png">


it was a bit hard to find where the error is actually coming from because either there's no source map on the client side or it's there but it's not showing the exact TS file and it's location, maybe some time in future I'm gonna have to investigate that as well if it starts to bother me a lot 😄 

## Solution
Figured out that in this file `proxy-render.tsx` there is actually a <div /> being returned as a child of a <p /> and fixed it.

I've landed this PR as my first contribution to see how much it is welcomed from your side, hope you find it useful. 
More PRs to come!
