### PR TITLE
修复了Linux系统下，系统代理选项和全局模式同时打开会导致GUI卡死

### DIFF
--- a/src-tauri/src/core/sysopt.rs
+++ b/src-tauri/src/core/sysopt.rs
@@ -25,7 +25,7 @@ pub struct Sysopt {
 #[cfg(target_os = "windows")]
 static DEFAULT_BYPASS: &str = "localhost;127.*;192.168.*;<local>";
 #[cfg(target_os = "linux")]
-static DEFAULT_BYPASS: &str = "localhost,127.0.0.1/8,::1";
+static DEFAULT_BYPASS: &str = "localhost,127.0.0.1,::1";
 #[cfg(target_os = "macos")]
 static DEFAULT_BYPASS: &str = "127.0.0.1,localhost,<local>";
 


### PR DESCRIPTION
如题，之前发现Linux系统下同时打开系统代理选项和全局模式会导致GUI卡死（[这个issue](https://github.com/zzzgydi/clash-verge/issues/458)）。花时间研究了一下，发现是因为对Linux的DEFAULT_BYPASS，也就是不使用代理的主机设置不正确。

原来的配置中包含了`127.0.0.1/8`，但是这个语法在Linux系统下似乎不支持，开启系统代理后，curl等网络工具都不会让127.0.0.1绕过代理（但是用localhost则没有问题），而clash-verge的GUI显示内核的信息是通过调用127.0.0.1:9090的api来完成的。这导致打开全局模式后，127.0.0.1:9090的流量也转发给代理，axios无法获取正确的信息，导致GUI上一片空白。

修改为127.0.0.1之后，就可以正确地将这个流量绕过代理，GUI也不会卡死了。

As the title suggests, I previously found that turning on both the system proxy option and global mode on Linux systems causes the GUI to get stuck ([this issue](https://github.com/zzzgydi/clash-verge/issues/458)). After spending some time researching, I found that it was because the DEFAULT_BYPASS, or host without proxy, setting for Linux was incorrect.

The original configuration included `127.0.0.1/8`, but this syntax doesn't seem to be supported under Linux. With the system proxy turned on, network tools such as curl won't let 127.0.0.1 bypass the proxy (but with localhost there is no problem), and the clash-verge GUI displays the kernel's information by calling 127.0.0.1:9090 api to do so. This causes the traffic from 127.0.0.1:9090 to also be forwarded to the proxy when global mode is turned on, and axios is unable to get the correct information, resulting in a blank GUI.

After modifying it to 127.0.0.1, this traffic is correctly bypassed to the proxy and the GUI doesn't get stuck.