### PR TITLE
Use polkit to elevate permission instaed of sudo

### DIFF
--- a/src-tauri/src/core/manager.rs
+++ b/src-tauri/src/core/manager.rs
@@ -28,7 +28,7 @@ pub fn grant_permission(core: String) -> anyhow::Result<()> {
     let output = {
         let path = path.replace(' ', "\\ "); // 避免路径中有空格
         let shell = format!("setcap cap_net_bind_service,cap_net_admin=+ep {path}");
-        Command::new("sudo")
+        Command::new("pkexec")
             .arg("sh")
             .arg("-c")
             .arg(shell)


### PR DESCRIPTION
All major desktop environments have polkit to elevate permission and Clash Verge should use it to execute `setcap` without requiring user to configure sudo askpass.

![image](https://github.com/zzzgydi/clash-verge/assets/61745317/0e1dfdb2-daad-4210-8bd9-a795bbec71d0)
