### PR TITLE
feat: Subscription URL TextField use multiline

### DIFF
--- a/src/components/profile/profile-viewer.tsx
+++ b/src/components/profile/profile-viewer.tsx
@@ -188,7 +188,12 @@ export const ProfileViewer = forwardRef<ProfileViewerRef, Props>(
               name="url"
               control={control}
               render={({ field }) => (
-                <TextField {...text} {...field} label={t("Subscription URL")} />
+                <TextField
+                  {...text}
+                  {...field}
+                  multiline
+                  label={t("Subscription URL")}
+                />
               )}
             />
 


### PR DESCRIPTION
*Subscription link that are too long can make reading difficult, so use multiline TextField.